### PR TITLE
I don't think 'Issue comments' is a used action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ PyDocTeur will use the following environment (and `.env` file) variables:
 - `LOGGING` (optional): logging dict-config as a yaml file, see below.
 
 
+## Github WebHook Configuration
+
+You'll need to setup a github webhook using the `application/json` content type, sending:
+
+- Check suites
+- Pull request review comments
+- Pull request reviews
+- Pull requests
+- Pushes
+
+
 ## Logging
 
 PyDocTeur use the `pydocteur` logger, and used libs use the following

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You'll need to setup a github webhook using the `application/json` content type,
 - Pull request reviews
 - Pull requests
 - Pushes
+- Issue comments (which in fact also contains pull request comments)
 
 
 ## Logging

--- a/pydocteur/github_api.py
+++ b/pydocteur/github_api.py
@@ -36,18 +36,26 @@ def get_pull_request(payload):
     if not head_sha:
         head_sha = payload.get("check_run", {}).get("head_sha")
     if head_sha:
+        logger.debug(f"Found from head_sha {head_sha}.")
         return get_pr_from_sha(head_sha)
 
     pr_number = payload.get("pull_request", {}).get("number")
     if pr_number:
+        logger.debug(f"Found from pull request number {pr_number}.")
         return gh_repo.get_pull(pr_number)
 
     issue_number = payload.get("issue", {}).get("number")
     if issue_number:
-        return gh_repo.get_pull(issue_number)
-
+        logger.debug("Trying to find PR from issue number %s", issue_number)
+        try:
+            pull_request = gh_repo.get_pull(issue_number)
+            logger.debug(f"Found from issue number {issue_number}.")
+            return pull_request
+        except gh.GithubException:
+            pass
     sha = payload.get("before")
     if sha:
+        logger.debug(f"Found from `before` sha {sha}.")
         return get_pr_from_sha(sha)
 
     logger.warning("Unknown payload, (action: %s)", payload.get("action", ""))


### PR DESCRIPTION
But it cause 503s when we:
```
issue_number = payload.get("issue", {}).get("number")
if issue_number:
    return gh_repo.get_pull(issue_number)
```

in case it's really an issue and not a PR, it raises an exception here.