### PR TITLE
We're getting here when it's not a PR, like a comment in an issue.

### DIFF
--- a/pydocteur/github_api.py
+++ b/pydocteur/github_api.py
@@ -44,8 +44,9 @@ def get_pull_request(payload):
         logger.debug(f"Found from pull request number {pr_number}.")
         return gh_repo.get_pull(pr_number)
 
-    issue_number = payload.get("issue", {}).get("number")
-    if issue_number:
+    issue = payload.get("issue", {})
+    issue_number = issue.get("number")
+    if issue_number and issue.get("pull_request"):
         logger.debug("Trying to find PR from issue number %s", issue_number)
         try:
             pull_request = gh_repo.get_pull(issue_number)
@@ -58,7 +59,7 @@ def get_pull_request(payload):
         logger.debug(f"Found from `before` sha {sha}.")
         return get_pr_from_sha(sha)
 
-    logger.warning("Unknown payload, (action: %s)", payload.get("action", ""))
+    logger.debug("Payload (action: %s) is not from a PR.", payload.get("action", "(no action)"))
     return None
 
 


### PR DESCRIPTION
First part is about skipping a useless HTTP request: if there's no `pull_request` attribute, it's a real issue, no need to query the API.

Second part changes a warning to a debug, beacuse it's expected to land here in case it's really an issue, not a PR.

Sadly the `pull_request` attribute don't contains the pull request id (which is equal to the issue id, it's the same thing):
```
 "pull_request": {
      "url": "https://api.github.com/repos/python/python-docs-fr/pulls/1656",
      "html_url": "https://github.com/python/python-docs-fr/pull/1656",
      "diff_url": "https://github.com/python/python-docs-fr/pull/1656.diff",
      "patch_url": "https://github.com/python/python-docs-fr/pull/1656.patch"
    },
```
so we still have to use issue_number to fetch it.
